### PR TITLE
Had to look inside the .py file to find the ide.key

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This plugin can initiate and terminate a debugging session by launching your def
 		}
 	}
 
-If you don't configure the URL, the plugin will still listen for debugging connections from XDebug, but you will need to trigger XDebug <a href="http://XDebug.org/docs/remote">some other way</a>.
+If you don't configure the URL, the plugin will still listen for debugging connections from XDebug, but you will need to trigger XDebug <a href="http://XDebug.org/docs/remote">for a remote session</a>. The IDE Key should be "sublime.xdebug".
 
 ## Gutter icon color
 


### PR DESCRIPTION
Just clarified that ide.key should be set to "sublime.xdebug". At least that's how it started working for me :)
