### PR TITLE
fileuri are url encoded so it needs to be decoded

### DIFF
--- a/Xdebug.py
+++ b/Xdebug.py
@@ -21,7 +21,7 @@ current_icon = '../Xdebug/icons/current'
 current_breakpoint_icon = '../Xdebug/icons/current_breakpoint'
 
 class Stack(object):
-    def __init__(file, lineno, where):
+    def __init__(self, file, lineno, where):
         self.file = file
         self.lineno = lineno
         self.where = where

--- a/Xdebug.py
+++ b/Xdebug.py
@@ -428,7 +428,18 @@ class XdebugCommand(sublime_plugin.TextCommand):
                 sublime.status_message('Xdebug: No URL defined in project settings file.')
             window = sublime.active_window()
             window.run_command('hide_panel', {"panel": 'output.xdebug_inspect'})
-            window.set_layout(original_layout)
+            views = window.views_in_group(1) + window.views_in_group(2)
+            if (set([v.name() for v in views]) == set(['Xdebug Context', 'Xdebug Stack'])):
+                for v in views:
+                    window.focus_view(v)
+                    window.run_command("close_file")
+                window.set_layout({
+                        "cols": [0.0, 1.0],
+                        "rows": [0.0, 1.0],
+                        "cells": [[0, 0, 1, 1]]
+                    })
+            else:
+                window.set_layout(original_layout)
 
 
 class XdebugContinueCommand(sublime_plugin.TextCommand):

--- a/Xdebug.py
+++ b/Xdebug.py
@@ -497,13 +497,13 @@ class XdebugContinueCommand(sublime_plugin.TextCommand):
                         propType = unicode(child.getAttribute('type'))
                         propValue = None
                         try:
-                            propValue = unicode(' '.join(base64.b64decode(t.data) for t in child.childNodes if t.nodeType == t.TEXT_NODE or t.nodeType == t.CDATA_SECTION_NODE))
+                            propValue = ' '.join(base64.b64decode(t.data).decode('utf-8') for t in child.childNodes if t.nodeType == t.TEXT_NODE or t.nodeType == t.CDATA_SECTION_NODE)
                         except:
                             propValue = unicode(' '.join(t.data for t in child.childNodes if t.nodeType == t.TEXT_NODE or t.nodeType == t.CDATA_SECTION_NODE))
                         if propName:
                             if propName.lower().find('password') != -1:
                                 propValue = unicode('*****')
-                            result = result + unicode(propName + ' [' + propType + '] = ' + str(propValue) + '\n')
+                            result = result + propName + ' [' + propType + '] = ' + propValue + '\n'
                             result = result + getValues(child)
                             if xdebug_current:
                                 xdebug_current.add_context_data(propName, propType, propValue)

--- a/Xdebug.py
+++ b/Xdebug.py
@@ -7,6 +7,7 @@ import threading
 import types
 import json
 import webbrowser
+import urllib2
 from xml.dom.minidom import parseString
 
 
@@ -479,7 +480,7 @@ class XdebugContinueCommand(sublime_plugin.TextCommand):
             if child.nodeName == 'xdebug:message':
                 #print '>>>break ' + child.getAttribute('filename') + ':' + child.getAttribute('lineno')
                 sublime.status_message('Xdebug: breakpoint')
-                xdebug_current = show_file(self.view.window(), child.getAttribute('filename'))
+                xdebug_current = show_file(self.view.window(), urllib2.unquote(child.getAttribute('filename')))
                 xdebug_current.current(int(child.getAttribute('lineno')))
 
         if (res.getAttribute('status') == 'break'):
@@ -522,7 +523,7 @@ class XdebugContinueCommand(sublime_plugin.TextCommand):
                     propWhere = child.getAttribute('where')
                     propLevel = child.getAttribute('level')
                     propType = child.getAttribute('type')
-                    propFile = child.getAttribute('filename')
+                    propFile = urllib2.unquote(child.getAttribute('filename'))
                     propLine = child.getAttribute('lineno')
                     result = result + unicode('{level:>3}: {type:<10} {where:<10} {filename}:{lineno}\n' \
                                               .format(level=propLevel, type=propType, where=propWhere, lineno=propLine, filename=propFile))
@@ -708,6 +709,7 @@ def show_file(window, uri):
         transport, filename = uri.split(':///', 1)  # scheme:///C:/path/file => scheme, C:/path/file
     else:
         transport, filename = uri.split('://', 1)  # scheme:///path/file => scheme, /path/file
+    filename = urllib2.unquote(filename)
     if transport == 'file' and os.path.exists(filename):
         window = sublime.active_window()
         views = window.views()


### PR DESCRIPTION
Lots of functionality will be broken if file name contains characters like '{', '}'. 
